### PR TITLE
Experiment with multi-field forms

### DIFF
--- a/config/routes
+++ b/config/routes
@@ -4,4 +4,4 @@
 /favicon.ico FaviconR GET
 /robots.txt RobotsR GET
 
-/ HomeR GET
+/ HomeR GET POST

--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -4,6 +4,42 @@ import Import
 
 getHomeR :: Handler Html
 getHomeR = do
+    (form, enctype) <- generateFormPost testForm
     defaultLayout $ do
         setTitle "Welcome To Yesod!"
         $(widgetFile "home/index")
+
+postHomeR :: Handler Html
+postHomeR = do
+    ((res, _form), _enctype) <- runFormPost testForm
+    case res of
+      FormSuccess fields -> do
+          setMessage $ toHtml $ unwords $ values fields
+          redirect HomeR
+      _ -> do
+          setMessage "Unsuccessful"
+          redirect HomeR
+
+data TestFields = TestFields
+    { values :: [Text]
+    }
+
+multiTextField ::  Field Handler [Text]
+multiTextField = Field
+    { fieldParse = \ts _fs -> multiTextFieldParse ts
+    , fieldView = multiTextFieldView
+    , fieldEnctype = UrlEncoded
+    }
+
+multiTextFieldParse :: [Text] -> Handler (Either (SomeMessage App) (Maybe [Text]))
+multiTextFieldParse = return . Right . Just
+
+multiTextFieldView :: FieldViewFunc Handler [Text]
+multiTextFieldView theId name attrs evals isReq = do
+    let vals = either (const []) id evals
+    $(whamletFile "views/multi-text-field.hamlet")
+
+testForm :: Form TestFields
+testForm = renderDivs $
+    TestFields
+        <$> areq multiTextField "Value" Nothing

--- a/templates/home/index.hamlet
+++ b/templates/home/index.hamlet
@@ -1,2 +1,6 @@
 <div .container>
   <p> Hello World!
+
+<form method=post action=@{HomeR} enctype=#{enctype}>
+  ^{form}
+  <button #submit>Submit!

--- a/views/multi-text-field.hamlet
+++ b/views/multi-text-field.hamlet
@@ -1,0 +1,5 @@
+<fieldset id="#{name}-fieldset">
+  $forall val <- vals
+    <input id="#{theId}" name="#{name}" *{attrs} type="text" :isReq:required value="#{val}">
+
+<input type="button" value="Add" onclick="var s = document.createElement('input'); s.type='text'; s.name='#{name}'; fieldset = document.getElementById('#{name}-fieldset'); fieldset.appendChild(s); return false;">


### PR DESCRIPTION
I don't know what you'd call this, but we're going to need to let users add
arbitrary numbers of sets. This means we'll need to let users add any number
of fields to the form to represent their sets. I didn't know how to make this
work, so I wanted to do a small experiment to figure out how this worked.

Turns out, while it's a bit unintuitive at first, the end result isn't that
bad. The gist is that Yesod is smarter than it would seem on the surface here,
and will concatenate all fields with the same name into a list of values for
you automatically. All that's left is to write a small custom field that
understands that there might be many of them.

This commit implements one such field, and actually includes the code for
adding new fields to the form for the sake of simplicity. There's very little
data validation here, we're basically just saying "give me all of the data and
I'll deal with it", but it gets us to where we want to be: a single field
(technically a fieldset, I suppose) that is able to dynamically add arbitrary
numbers of values to itself.

This code is going to be removed eventually, but I wanted to open this PR for
feedback and to serve as a reference for myself down the line.