### PR TITLE
Experiment with Elm for implementing workout form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cabal.sandbox.config
 *.keter
 .sass-cache/
 .env
+elm-stuff

--- a/elm-test/Main.elm
+++ b/elm-test/Main.elm
@@ -1,0 +1,90 @@
+module Main exposing (main)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onInput, onClick)
+
+type WeightUnit
+    = Pounds
+    | Kilos
+
+type alias WorkoutSet =
+    { reps : List Int
+    , weight : Int
+    , unitOfMeasurement : WeightUnit
+    }
+
+type Msg
+    = RepsUpdated String
+    | WeightUpdated String
+    | UnitUpdated WeightUnit
+
+initialWorkoutSet : WorkoutSet
+initialWorkoutSet =
+    { reps = []
+    , weight = 0
+    , unitOfMeasurement = Kilos
+    }
+
+view : WorkoutSet -> Html Msg
+view set =
+    div []
+        [ input [type_ "text", placeholder "reps", onInput RepsUpdated ] []
+        , input [type_ "text", placeholder "weight", onInput WeightUpdated] []
+        , select [ onInput (UnitUpdated << parseUnit) ]
+            [ viewUnit set.unitOfMeasurement Pounds
+            , viewUnit set.unitOfMeasurement Kilos
+            ]
+        , text <| format set
+        ]
+
+viewUnit : WeightUnit -> WeightUnit -> Html Msg
+viewUnit current unit = option
+    [ value <| toString unit
+    , selected <| current == unit
+    ]
+    [ text <| toString unit ]
+
+update : Msg -> WorkoutSet -> WorkoutSet
+update msg set = case msg of
+    RepsUpdated str ->
+        { set | reps = parseReps str }
+    WeightUpdated str ->
+        { set | weight = parseInt str }
+    UnitUpdated unit ->
+        { set | unitOfMeasurement = unit }
+
+parseReps : String -> List Int
+parseReps str
+    =  String.split "+" str
+    |> List.map String.trim
+    |> List.map parseInt
+
+parseInt : String -> Int
+parseInt s
+    = String.toInt s
+    |> Result.withDefault 0
+
+parseUnit : String -> WeightUnit
+parseUnit str = case str of
+    "Pounds" -> Pounds
+    "Kilos" -> Kilos
+    _ -> Debug.crash "Not a valid unit of measurement"
+
+format : WorkoutSet -> String
+format set =
+    let
+        formattedReps = String.join " + " <| List.map toString set.reps
+        formattedWeight = toString set.weight
+        formattedUnits = case set.unitOfMeasurement of
+            Pounds -> "lbs"
+            Kilos -> "kgs"
+    in
+       formattedReps ++ " @ " ++ formattedWeight ++ formattedUnits
+
+main : Program Never WorkoutSet Msg
+main = Html.beginnerProgram
+    { model = initialWorkoutSet
+    , view = view
+    , update = update
+    }

--- a/elm-test/Main.elm
+++ b/elm-test/Main.elm
@@ -4,6 +4,12 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput, onClick)
 
+import Json.Decode
+
+onChange : (String -> msg) -> Html.Attribute msg
+onChange tagger =
+  Html.Events.on "change" (Json.Decode.map tagger Html.Events.targetValue)
+
 type WeightUnit
     = Pounds
     | Kilos
@@ -37,7 +43,7 @@ view set =
     div []
         [ input [type_ "text", placeholder "reps", onInput RepsUpdated ] []
         , input [type_ "text", placeholder "weight", onInput (WeightUpdated << parseInt)] []
-        , select [ onInput (WeightUnitUpdated << parseUnit) ]
+        , select [ onChange (WeightUnitUpdated << parseUnit) ]
             [ viewUnit set.weight Pounds
             , viewUnit set.weight Kilos
             ]

--- a/elm-test/elm-package.json
+++ b/elm-test/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
Trying to wrap my head around how this (fairly complex) form would work in
Yesod made me start to wonder if something like Elm wouldn't be better suited
for the job. This is a small experiment in implementing the most basic
component I'll need for inputting workout info.

I think this experiment was a huge success, and I think that I'll probably
move forward with this model. Parsing this info at the client level and then
simply sending the results to Yesod will also let me focus on an API for the
backend, which will be necessary once I build out the mobile client anyway.

This component has 3 fields:

1. A reps field. This field can take reps for compound movements by entering
   the reps separated by "+" (and any amount of whitespace).
2. The weight for the movements. This field expects an Integer
3. A dropdown for selecting the unit of measurement. This is limited to Kilos
   and Pounds, and so crashes in the event that it gets a unit of measurement
   it doesn't expect.

The result is parsed and formatted for display to the right of the fields for
the sake of demonstration.

Some improvements I could make:

- Limit input for reps to numbers, whitespace, and "+"
- Limit input for weight to numbers

Next steps:

- Build a component that can dynamically add/remove these components and
  combine the result into something more useful.
- Add data validation to ensure that each list of reps is the same length as
  the rest and also matches the list of movements in the parent.