### PR TITLE
Extract weight selector into standalone component

### DIFF
--- a/elm/Swole/Components/SingleSet.elm
+++ b/elm/Swole/Components/SingleSet.elm
@@ -10,10 +10,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput, onClick)
 
-import Swole.Types exposing
-    ( parseScheme
-    , schemeLength
-    )
+import Swole.Types exposing (schemeLength)
 import Swole.Types.Weight exposing (Weight, WeightUnit(..))
 import Swole.Components.Weight as WeightComponent
 

--- a/elm/Swole/Components/Weight.elm
+++ b/elm/Swole/Components/Weight.elm
@@ -1,0 +1,79 @@
+module Swole.Components.Weight exposing
+    ( Msg(..)
+    , update
+    , view
+    )
+
+import Html exposing
+    ( Html
+    , div
+    , input
+    , option
+    , select
+    , text
+    )
+
+import Html.Attributes exposing (placeholder, selected, type_, value)
+import Html.Events exposing (onInput)
+import Helpers.Events exposing (onChange)
+
+import Swole.Types.Weight exposing
+    ( Weight
+    , WeightUnit(..)
+    , toWeightUnit
+    )
+
+type Msg
+    = AmountChanged Int
+    | UnitChanged WeightUnit
+
+view : Weight -> Html Msg
+view weight =
+    div []
+        [ amountField weight.amount
+        , unitPicker weight.unit
+        ]
+
+update : Msg -> Weight -> Weight
+update msg weight = case msg of
+    AmountChanged amount ->
+        { weight | amount = amount }
+
+    UnitChanged unit ->
+        { weight | unit = unit }
+
+amountField : Int -> Html Msg
+amountField v =
+    input
+        [ type_ "text"
+        , placeholder "weight"
+        , value <| toString v
+        , onInput (AmountChanged << parseAmount)
+        ]
+        []
+
+unitPicker : WeightUnit -> Html Msg
+unitPicker unit =
+    select
+        [ onChange (UnitChanged << parseUnit) ]
+        [ unitOption unit Pounds
+        , unitOption unit Kilos
+        ]
+
+unitOption : WeightUnit -> WeightUnit -> Html Msg
+unitOption current unit =
+    option
+        [ value <| toString unit
+        , selected <| current == unit
+        ]
+        [ text <| toString unit ]
+
+parseAmount : String -> Int
+parseAmount str
+    = String.toInt str
+    |> Result.withDefault 0
+
+parseUnit : String -> WeightUnit
+parseUnit str
+    = toWeightUnit str
+    |> Result.withDefault Kilos

--- a/elm/Swole/Types.elm
+++ b/elm/Swole/Types.elm
@@ -1,26 +1,16 @@
 module Swole.Types exposing
-    ( WeightUnit (..)
-    , Weight
-    , WorkoutSet
+    ( WorkoutSet
     , formatReps
     , parseScheme
     , schemeLength
     , setToString
-    , toWeightUnit
     , updateWeightAmount
     , updateWeightUnit
     , weightToString
     , weightUnitToString
     )
 
-type WeightUnit
-    = Pounds
-    | Kilos
-
-type alias Weight =
-    { amount : Int
-    , unit : WeightUnit
-    }
+import Swole.Types.Weight exposing (Weight, WeightUnit(..))
 
 type alias WorkoutSet =
     { reps : List Int
@@ -36,12 +26,6 @@ schemeLength : String -> Int
 schemeLength str
     = parseScheme str
     |> List.length
-
-toWeightUnit : String -> Result String WeightUnit
-toWeightUnit str = case str of
-    "Pounds" -> Ok Pounds
-    "Kilos" -> Ok Kilos
-    _ -> Err ("Not a valid weight unit: " ++ str)
 
 weightToString : Weight -> String
 weightToString weight =

--- a/elm/Swole/Types.elm
+++ b/elm/Swole/Types.elm
@@ -1,21 +1,6 @@
 module Swole.Types exposing
-    ( WorkoutSet
-    , formatReps
-    , parseScheme
-    , schemeLength
-    , setToString
-    , updateWeightAmount
-    , updateWeightUnit
-    , weightToString
-    , weightUnitToString
+    ( schemeLength
     )
-
-import Swole.Types.Weight exposing (Weight, WeightUnit(..))
-
-type alias WorkoutSet =
-    { reps : List Int
-    , weight : Weight
-    }
 
 parseScheme : String -> List String
 parseScheme str
@@ -26,33 +11,3 @@ schemeLength : String -> Int
 schemeLength str
     = parseScheme str
     |> List.length
-
-weightToString : Weight -> String
-weightToString weight =
-    toString weight.amount ++ " " ++ (weightUnitToString weight.unit)
-
-weightUnitToString : WeightUnit -> String
-weightUnitToString unit = case unit of
-    Pounds -> "lbs"
-    Kilos -> "kgs"
-
-formatReps : List Int -> String
-formatReps reps = String.join " + " (List.map toString reps)
-
-setToString : WorkoutSet -> String
-setToString set =
-       formatReps set.reps ++ " @ " ++ weightToString set.weight
-
-updateWeightUnit : WorkoutSet -> WeightUnit -> WorkoutSet
-updateWeightUnit set unit =
-    let
-        current = set.weight
-    in
-       { set | weight = { current | unit = unit } }
-
-updateWeightAmount : WorkoutSet -> Int -> WorkoutSet
-updateWeightAmount set amount =
-    let
-        current = set.weight
-    in
-       { set | weight = { current | amount = amount } }

--- a/elm/Swole/Types/Weight.elm
+++ b/elm/Swole/Types/Weight.elm
@@ -1,0 +1,20 @@
+module Swole.Types.Weight exposing
+    ( Weight
+    , WeightUnit(..)
+    , toWeightUnit
+    )
+
+type WeightUnit
+    = Pounds
+    | Kilos
+
+type alias Weight =
+    { amount : Int
+    , unit : WeightUnit
+    }
+
+toWeightUnit : String -> Result String WeightUnit
+toWeightUnit str = case str of
+    "Pounds" -> Ok Pounds
+    "Kilos" -> Ok Kilos
+    _ -> Err ("Not a valid weight unit: " ++ str)


### PR DESCRIPTION
I moved away from modeling this selection thing as working on the Weight
type specifically because I felt like my model was nested too deeply inside 
SingleSet. As it turns out, I think that I was _actually_ just modeling my 
components too shallow, and should have been maintaining a 1:1 relationship 
between my models and my components. This is the first step towards trying
to make that work, and moves Weight into a standalone component (and
isolates the type itself into a new module) so that it is easier to deal
with.

I'm also taking this opportunity to remove a bunch of dead code that we're
no-longer using.