### PR TITLE
Use a sum type for Weight

### DIFF
--- a/elm/Swole/Components/SingleSet.elm
+++ b/elm/Swole/Components/SingleSet.elm
@@ -11,7 +11,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onInput, onClick)
 
 import Swole.Types exposing (schemeLength)
-import Swole.Types.Weight exposing (Weight, WeightUnit(..))
+import Swole.Types.Weight exposing (Weight(..))
 import Swole.Components.Weight as WeightComponent
 
 type Msg
@@ -30,10 +30,7 @@ initialModel : Int -> Model
 initialModel count =
     { movementCount = count
     , repScheme = ""
-    , weight =
-        { amount = 0
-        , unit = Kilos
-        }
+    , weight = Kilos 0
     , validRepScheme = True
     }
 

--- a/elm/Swole/Components/Weight.elm
+++ b/elm/Swole/Components/Weight.elm
@@ -18,29 +18,33 @@ import Html.Events exposing (onInput)
 import Helpers.Events exposing (onChange)
 
 import Swole.Types.Weight exposing
-    ( Weight
-    , WeightUnit(..)
-    , toWeightUnit
+    ( Weight(..)
+    , availableWeightUnits
+    , hasUnit
+    , setAmount
+    , setUnit
+    , toWeightConstructor
+    , weightAmount
     )
 
 type Msg
     = AmountChanged Int
-    | UnitChanged WeightUnit
+    | UnitChanged (Int -> Weight)
 
 view : Weight -> Html Msg
 view weight =
     div []
-        [ amountField weight.amount
-        , unitPicker weight.unit
+        [ amountField <| weightAmount weight
+        , unitPicker weight
         ]
 
 update : Msg -> Weight -> Weight
 update msg weight = case msg of
     AmountChanged amount ->
-        { weight | amount = amount }
+        setAmount weight amount
 
-    UnitChanged unit ->
-        { weight | unit = unit }
+    UnitChanged newUnit ->
+        setUnit weight newUnit
 
 amountField : Int -> Html Msg
 amountField v =
@@ -52,28 +56,26 @@ amountField v =
         ]
         []
 
-unitPicker : WeightUnit -> Html Msg
-unitPicker unit =
+unitPicker : Weight -> Html Msg
+unitPicker weight =
     select
         [ onChange (UnitChanged << parseUnit) ]
-        [ unitOption unit Pounds
-        , unitOption unit Kilos
-        ]
+        (List.map (unitOption weight) availableWeightUnits)
 
-unitOption : WeightUnit -> WeightUnit -> Html Msg
-unitOption current unit =
+unitOption : Weight -> String -> Html Msg
+unitOption weight unit =
     option
-        [ value <| toString unit
-        , selected <| current == unit
+        [ value unit
+        , selected <| hasUnit weight unit
         ]
-        [ text <| toString unit ]
+        [ text unit ]
 
 parseAmount : String -> Int
 parseAmount str
     = String.toInt str
     |> Result.withDefault 0
 
-parseUnit : String -> WeightUnit
+parseUnit : String -> (Int -> Weight)
 parseUnit str
-    = toWeightUnit str
+    = toWeightConstructor str
     |> Result.withDefault Kilos

--- a/elm/Swole/Components/Weight.elm
+++ b/elm/Swole/Components/Weight.elm
@@ -17,16 +17,7 @@ import Html.Attributes exposing (placeholder, selected, type_, value)
 import Html.Events exposing (onInput)
 import Helpers.Events exposing (onChange)
 
-import Swole.Types.Weight exposing
-    ( Weight(..)
-    , WeightUnit
-    , availableWeightUnits
-    , hasUnit
-    , setAmount
-    , setUnit
-    , toWeightConstructor
-    , weightAmount
-    )
+import Swole.Types.Weight as Weight exposing (Weight(..), WeightUnit)
 
 type Msg
     = AmountChanged Int
@@ -35,17 +26,17 @@ type Msg
 view : Weight -> Html Msg
 view weight =
     div []
-        [ amountField <| weightAmount weight
+        [ amountField <| Weight.amount weight
         , unitPicker weight
         ]
 
 update : Msg -> Weight -> Weight
 update msg weight = case msg of
     AmountChanged amount ->
-        setAmount weight amount
+        Weight.setAmount weight amount
 
     UnitChanged newUnit ->
-        setUnit weight newUnit
+        Weight.setUnit weight newUnit
 
 amountField : Int -> Html Msg
 amountField v =
@@ -61,13 +52,13 @@ unitPicker : Weight -> Html Msg
 unitPicker weight =
     select
         [ onChange (UnitChanged << parseUnit) ]
-        (List.map (unitOption weight) availableWeightUnits)
+        (List.map (unitOption weight) Weight.availableUnits)
 
 unitOption : Weight -> String -> Html Msg
 unitOption weight unit =
     option
         [ value unit
-        , selected <| hasUnit weight unit
+        , selected <| Weight.hasUnit weight unit
         ]
         [ text unit ]
 
@@ -78,5 +69,5 @@ parseAmount str
 
 parseUnit : String -> WeightUnit
 parseUnit str
-    = toWeightConstructor str
+    = Weight.toUnit str
     |> Result.withDefault Kilos

--- a/elm/Swole/Components/Weight.elm
+++ b/elm/Swole/Components/Weight.elm
@@ -19,6 +19,7 @@ import Helpers.Events exposing (onChange)
 
 import Swole.Types.Weight exposing
     ( Weight(..)
+    , WeightUnit
     , availableWeightUnits
     , hasUnit
     , setAmount
@@ -29,7 +30,7 @@ import Swole.Types.Weight exposing
 
 type Msg
     = AmountChanged Int
-    | UnitChanged (Int -> Weight)
+    | UnitChanged WeightUnit
 
 view : Weight -> Html Msg
 view weight =
@@ -75,7 +76,7 @@ parseAmount str
     = String.toInt str
     |> Result.withDefault 0
 
-parseUnit : String -> (Int -> Weight)
+parseUnit : String -> WeightUnit
 parseUnit str
     = toWeightConstructor str
     |> Result.withDefault Kilos

--- a/elm/Swole/Types/Weight.elm
+++ b/elm/Swole/Types/Weight.elm
@@ -1,12 +1,12 @@
 module Swole.Types.Weight exposing
     ( Weight(..)
     , WeightUnit
-    , availableWeightUnits
+    , availableUnits
     , hasUnit
     , setAmount
     , setUnit
-    , toWeightConstructor
-    , weightAmount
+    , toUnit
+    , amount
     )
 
 type alias WeightUnit = Int -> Weight
@@ -15,8 +15,8 @@ type Weight
     = Pounds Int
     | Kilos Int
 
-toWeightConstructor : String -> Result String WeightUnit
-toWeightConstructor str = case str of
+toUnit : String -> Result String WeightUnit
+toUnit str = case str of
     "Pounds" -> Ok Pounds
     "Kilos" -> Ok Kilos
     _ -> Err ("Not a valid weight unit: " ++ str)
@@ -26,8 +26,8 @@ unitToString weight = case weight of
     Kilos _ -> "Kilos"
     Pounds _ -> "Pounds"
 
-availableWeightUnits : List String
-availableWeightUnits = List.map unitToString [Pounds 0, Kilos 0]
+availableUnits : List String
+availableUnits = List.map unitToString [Pounds 0, Kilos 0]
 
 setAmount : Weight -> Int -> Weight
 setAmount weight amount = case weight of
@@ -39,8 +39,8 @@ setUnit weight newUnit = case weight of
     Kilos amount -> newUnit amount
     Pounds amount -> newUnit amount
 
-weightAmount : Weight -> Int
-weightAmount weight = case weight of
+amount : Weight -> Int
+amount weight = case weight of
     Kilos n -> n
     Pounds n -> n
 

--- a/elm/Swole/Types/Weight.elm
+++ b/elm/Swole/Types/Weight.elm
@@ -1,20 +1,48 @@
 module Swole.Types.Weight exposing
-    ( Weight
-    , WeightUnit(..)
-    , toWeightUnit
+    ( Weight(..)
+    , availableWeightUnits
+    , hasUnit
+    , setAmount
+    , setUnit
+    , toWeightConstructor
+    , weightAmount
     )
 
-type WeightUnit
-    = Pounds
-    | Kilos
+type Weight
+    = Pounds Int
+    | Kilos Int
 
-type alias Weight =
-    { amount : Int
-    , unit : WeightUnit
-    }
-
-toWeightUnit : String -> Result String WeightUnit
-toWeightUnit str = case str of
+toWeightConstructor : String -> Result String (Int -> Weight)
+toWeightConstructor str = case str of
     "Pounds" -> Ok Pounds
     "Kilos" -> Ok Kilos
     _ -> Err ("Not a valid weight unit: " ++ str)
+
+availableWeightUnits : List String
+availableWeightUnits =
+    [ "Pounds"
+    , "Kilos"
+    ]
+
+setAmount : Weight -> Int -> Weight
+setAmount weight amount = case weight of
+    Kilos _ -> Kilos amount
+    Pounds _ -> Pounds amount
+
+setUnit : Weight -> (Int -> Weight) -> Weight
+setUnit weight newUnit = case weight of
+    Kilos amount -> newUnit amount
+    Pounds amount -> newUnit amount
+
+weightAmount : Weight -> Int
+weightAmount weight = case weight of
+    Kilos n -> n
+    Pounds n -> n
+
+unitToString : Weight -> String
+unitToString weight = case weight of
+    Kilos _ -> "Kilos"
+    Pounds _ -> "Pounds"
+
+hasUnit : Weight -> String -> Bool
+hasUnit weight unit = unitToString weight == unit

--- a/elm/Swole/Types/Weight.elm
+++ b/elm/Swole/Types/Weight.elm
@@ -21,11 +21,13 @@ toWeightConstructor str = case str of
     "Kilos" -> Ok Kilos
     _ -> Err ("Not a valid weight unit: " ++ str)
 
+unitToString : Weight -> String
+unitToString weight = case weight of
+    Kilos _ -> "Kilos"
+    Pounds _ -> "Pounds"
+
 availableWeightUnits : List String
-availableWeightUnits =
-    [ "Pounds"
-    , "Kilos"
-    ]
+availableWeightUnits = List.map unitToString [Pounds 0, Kilos 0]
 
 setAmount : Weight -> Int -> Weight
 setAmount weight amount = case weight of
@@ -41,11 +43,6 @@ weightAmount : Weight -> Int
 weightAmount weight = case weight of
     Kilos n -> n
     Pounds n -> n
-
-unitToString : Weight -> String
-unitToString weight = case weight of
-    Kilos _ -> "Kilos"
-    Pounds _ -> "Pounds"
 
 hasUnit : Weight -> String -> Bool
 hasUnit weight unit = unitToString weight == unit

--- a/elm/Swole/Types/Weight.elm
+++ b/elm/Swole/Types/Weight.elm
@@ -1,5 +1,6 @@
 module Swole.Types.Weight exposing
     ( Weight(..)
+    , WeightUnit
     , availableWeightUnits
     , hasUnit
     , setAmount
@@ -8,11 +9,13 @@ module Swole.Types.Weight exposing
     , weightAmount
     )
 
+type alias WeightUnit = Int -> Weight
+
 type Weight
     = Pounds Int
     | Kilos Int
 
-toWeightConstructor : String -> Result String (Int -> Weight)
+toWeightConstructor : String -> Result String WeightUnit
 toWeightConstructor str = case str of
     "Pounds" -> Ok Pounds
     "Kilos" -> Ok Kilos
@@ -29,7 +32,7 @@ setAmount weight amount = case weight of
     Kilos _ -> Kilos amount
     Pounds _ -> Pounds amount
 
-setUnit : Weight -> (Int -> Weight) -> Weight
+setUnit : Weight -> WeightUnit -> Weight
 setUnit weight newUnit = case weight of
     Kilos amount -> newUnit amount
     Pounds amount -> newUnit amount


### PR DESCRIPTION
I'm not positive about this change, but it was a fun exercise. The general
idea is to work with Weight types as a sum type instead of as a product type.
This resembles how I'd like them to _actually_ look a bit more, but as you can
see it introduces a _lot_ more overhead to the type to make up for the fact
that the units are now constructors and so can't be passed around in quite the
same way.