### PR TITLE
Add lenses for Weight.amount and Weight.unit

### DIFF
--- a/elm/Lens.elm
+++ b/elm/Lens.elm
@@ -1,0 +1,6 @@
+module Lens exposing ( Lens )
+
+type alias Lens whole part = {
+    get : whole -> part,
+    set : part -> whole -> whole
+}

--- a/elm/Swole/Components/Weight.elm
+++ b/elm/Swole/Components/Weight.elm
@@ -17,7 +17,12 @@ import Html.Attributes exposing (placeholder, selected, type_, value)
 import Html.Events exposing (onInput)
 import Helpers.Events exposing (onChange)
 
-import Swole.Types.Weight as Weight exposing (Weight(..), WeightUnit)
+import Swole.Types.Weight as Weight exposing
+    ( Weight(..)
+    , WeightUnit
+    , weightAmount
+    , weightUnit
+    )
 
 type Msg
     = AmountChanged Int
@@ -26,17 +31,17 @@ type Msg
 view : Weight -> Html Msg
 view weight =
     div []
-        [ amountField <| Weight.amount weight
+        [ amountField <| weightAmount.get weight
         , unitPicker weight
         ]
 
 update : Msg -> Weight -> Weight
 update msg weight = case msg of
-    AmountChanged amount ->
-        Weight.setAmount weight amount
+    AmountChanged amt ->
+        weightAmount.set amt weight
 
     UnitChanged newUnit ->
-        Weight.setUnit weight newUnit
+        weightUnit.set newUnit weight
 
 amountField : Int -> Html Msg
 amountField v =

--- a/elm/Swole/Types/Weight.elm
+++ b/elm/Swole/Types/Weight.elm
@@ -3,11 +3,12 @@ module Swole.Types.Weight exposing
     , WeightUnit
     , availableUnits
     , hasUnit
-    , setAmount
-    , setUnit
     , toUnit
-    , amount
+    , weightAmount
+    , weightUnit
     )
+
+import Lens exposing (Lens)
 
 type alias WeightUnit = Int -> Weight
 
@@ -29,20 +30,31 @@ unitToString weight = case weight of
 availableUnits : List String
 availableUnits = List.map unitToString [Pounds 0, Kilos 0]
 
-setAmount : Weight -> Int -> Weight
-setAmount weight amount = case weight of
-    Kilos _ -> Kilos amount
-    Pounds _ -> Pounds amount
+weightUnit : Lens Weight WeightUnit
+weightUnit =
+    let
+        get weight = case weight of
+            Kilos _ -> Kilos
+            Pounds _ -> Pounds
 
-setUnit : Weight -> WeightUnit -> Weight
-setUnit weight newUnit = case weight of
-    Kilos amount -> newUnit amount
-    Pounds amount -> newUnit amount
+        set unit weight = case weight of
+            Kilos amt -> unit amt
+            Pounds amt -> unit amt
+    in
+       Lens get set
 
-amount : Weight -> Int
-amount weight = case weight of
-    Kilos n -> n
-    Pounds n -> n
+weightAmount : Lens Weight Int
+weightAmount =
+    let
+        get weight = case weight of
+            Kilos amt -> amt
+            Pounds amt -> amt
+
+        set amt weight = case weight of
+            Kilos _ -> Kilos amt
+            Pounds _ -> Pounds amt
+    in
+       Lens get set
 
 hasUnit : Weight -> String -> Bool
 hasUnit weight unit = unitToString weight == unit


### PR DESCRIPTION
This adds a _super_ simple `Lens` type to the project and uses that to
construct lenses for getting/setting the amount and unit for a weight.

Unfortunately, I'm not sure how to use these with a qualified import. I'd
rather have these named as `amount` and `unit` so that I can do like
`Weight.unit.set` externally, but when I do that it tries to access the module
named `Weight.unit`, which isn't what I want.