### PR TITLE
Simplify MovementInput

### DIFF
--- a/elm/Swole/Components/MovementInput.elm
+++ b/elm/Swole/Components/MovementInput.elm
@@ -12,16 +12,15 @@ import Task
 import Dom exposing (focus)
 import List.Extra as List
 
-import Helpers.List as List
 import Helpers.Events exposing (onDeleteWhen)
 import Swole.Types.Movement exposing (Movement)
 
-type alias Movements = List (Int, Movement)
+type alias Movements = List Movement
 type alias Model = Movements
 
 type Msg
     = NoOp
-    | MovementChanged (Int, Movement)
+    | MovementChanged Int Movement
     | AddMovement
     | DeleteMovement Int
 
@@ -36,36 +35,30 @@ update msg movements =
         NoOp ->
             (movements, Cmd.none)
 
-        MovementChanged (idx, m) ->
+        MovementChanged idx m ->
             let
-                (newIdx, newMovements) = splitMovements (idx, m)
+                (newIdx, newMovements) = splitMovements idx m
                 (before, after) = movementsAround idx movements
                 allMovements = before ++ newMovements ++ after
             in
-                (List.enumerated allMovements, updateFocus newIdx)
+                (allMovements, updateFocus newIdx)
 
         AddMovement ->
             let
-                rawMovements = List.map Tuple.second movements
-                idx = List.length rawMovements
+                idx = List.length movements
             in
-                (List.enumerated <| rawMovements ++ [""], updateFocus idx)
+                (movements ++ [""], updateFocus idx)
 
         DeleteMovement idx ->
             let
-                newMovements
-                    = movements
-                    |> List.map Tuple.second
-                    |> List.removeAt idx
-
+                newMovements = List.removeAt idx movements
                 newIdx = max 0 (idx - 1)
             in
-               (List.enumerated newMovements, updateFocus newIdx)
+               (newMovements, updateFocus newIdx)
 
 movementsAround : Int -> Movements -> (List Movement, List Movement)
 movementsAround idx movements
     = movements
-    |> List.map Tuple.second
     |> List.splitAt idx
     |> Tuple.mapSecond (List.drop 1)
 
@@ -81,9 +74,14 @@ movementFields : Movements -> List (Html Msg)
 movementFields movements = case movements of
     [] -> [defaultMovementField]
     ms ->
-        let fields = List.intersperse plusLabel (List.map movementField ms)
+        let
+            fields
+                = ms
+                |> List.indexedMap movementField
+                |> List.intersperse plusLabel
         in
            fields ++ [plusButton]
+
 plusLabel : Html a
 plusLabel = text "+"
 
@@ -91,22 +89,22 @@ plusButton : Html Msg
 plusButton = button [ onClick AddMovement ] [ text "+" ]
 
 defaultMovementField : Html Msg
-defaultMovementField = movementField (0, "")
+defaultMovementField = movementField 0 ""
 
-movementField : (Int, Movement) -> Html Msg
-movementField (idx, movement) =
+movementField : Int -> Movement -> Html Msg
+movementField idx movement =
     input
         [ type_ "text"
         , placeholder "movement"
         , value movement
         , id <| "movement-" ++ toString idx
-        , onInput <| \m -> MovementChanged (idx, m)
+        , onInput <| MovementChanged idx
         , onDeleteWhen (movement == "") <| DeleteMovement idx
         ]
         []
 
-splitMovements : (Int, Movement) -> (Int, List Movement)
-splitMovements (idx, str)
+splitMovements : Int -> Movement -> (Int, List Movement)
+splitMovements idx str
     = str
     |> String.split "+"
     |> \ms -> ((idx + List.length ms - 1), ms)


### PR DESCRIPTION
I... don't know why I was under the impression that I needed to carry around
the index of the movements. What a weird misunderstanding to have. Turns out,
I can track the index without actually storing it anywhere by using
`List.indexedMap` (which is basically what my `enumerated` function was used
for anyway).

Removing the need to track a tuple here _greatly_ simplifies this code.

Additionally apparently I also forgot about curried functions? What a
roller-coaster this project is.