### PR TITLE
Rename MovementInput to Complex

### DIFF
--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -4,25 +4,26 @@ import Html exposing (..)
 import Html.Events exposing (onClick, onInput)
 import List.Extra as List
 
-import Swole.Components.MovementInput as MovementInput
+import Swole.Components.Complex as Complex
+import Swole.Types.Complex as Complex exposing (Complex)
 import Swole.Components.SingleSet as SingleSet
 import Helpers.Maybe as Maybe
 import Helpers.List as List
 
 type Msg
-    = MovementInputMsg MovementInput.Msg
+    = ComplexChanged Complex.Msg
     | SingleSetMsg (Int, SingleSet.Msg)
     | AddSet
     | DeleteSet Int
 
 type alias Model =
-    { movements : MovementInput.Model
+    { complex : Complex
     , setModels : List SingleSet.Model
     }
 
 initialModel : Model
 initialModel =
-    { movements = []
+    { complex = Complex.new
     , setModels = [SingleSet.initialModel 0]
     }
 
@@ -32,7 +33,7 @@ view model =
         sets = List.enumerated model.setModels
     in
         div []
-            [ map MovementInputMsg <| MovementInput.view model.movements
+            [ map ComplexChanged <| Complex.view model.complex
             , ol [] (List.map viewSet sets)
             , button [ onClick AddSet ] [ text "Add set" ]
             ]
@@ -61,11 +62,11 @@ update msg model =
             in
                ({ model | setModels = models }, Cmd.none)
 
-        MovementInputMsg msg ->
+        ComplexChanged msg ->
             let
-                (updated, cmd) = MovementInput.update msg model.movements
+                (updated, cmd) = Complex.update msg model.complex
             in
-                ({ model | movements = updated }, Cmd.map MovementInputMsg cmd)
+                ({ model | complex = updated }, Cmd.map ComplexChanged cmd)
 
         AddSet ->
             let

--- a/elm/Swole/Types/Complex.elm
+++ b/elm/Swole/Types/Complex.elm
@@ -1,0 +1,43 @@
+module Swole.Types.Complex exposing
+    ( Complex
+    , new
+    , fromMovement
+    , indexedMap
+    , insertAt
+    , movementCount
+    , removeAt
+    )
+
+import List.Extra as List
+
+import Swole.Types.Movement exposing (Movement)
+
+type alias Complex = List Movement
+
+new : Complex
+new = []
+
+fromMovement : Movement -> Complex
+fromMovement = String.split "+"
+
+indexedMap : (Int -> Movement -> a) -> Complex -> List a
+indexedMap = List.indexedMap
+
+insertAt : Int -> Complex -> Complex -> Complex
+insertAt idx new original =
+    let
+        (before, after) = splitAround idx original
+    in
+        before ++ new ++ after
+
+movementCount : Complex -> Int
+movementCount = List.length
+
+removeAt : Int -> Complex -> Complex
+removeAt = List.removeAt
+
+splitAround : Int -> Complex -> (Complex, Complex)
+splitAround idx complex
+    = complex
+    |> List.splitAt idx
+    |> Tuple.mapSecond (List.drop 1)


### PR DESCRIPTION
A list of movements is a complex. This updates our naming accordingly. I'm
also moving a bunch of the logic related to the Complex type into the Complex
type's module. This will let us effectively hide the fact that we're actually
dealing with a basic list of movements.